### PR TITLE
[Feature] 좌표,반경으로 주위 주차장 정보 조회하는 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,11 @@ ext {
 dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// database
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// kafka
 	implementation 'org.springframework.kafka:spring-kafka'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
 dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// database
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'

--- a/src/main/java/com/parkmate/parkingreadservice/ParkingreadserviceApplication.java
+++ b/src/main/java/com/parkmate/parkingreadservice/ParkingreadserviceApplication.java
@@ -2,9 +2,11 @@ package com.parkmate.parkingreadservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
+@EnableDiscoveryClient
 @SpringBootApplication
 public class ParkingreadserviceApplication {
 

--- a/src/main/java/com/parkmate/parkingreadservice/common/config/RedisConfig.java
+++ b/src/main/java/com/parkmate/parkingreadservice/common/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.parkmate.parkingreadservice.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.GeoOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public GeoOperations<String, String> geoOperations() {
+        return redisTemplate().opsForGeo();
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/common/utils/RedisUtil.java
+++ b/src/main/java/com/parkmate/parkingreadservice/common/utils/RedisUtil.java
@@ -1,0 +1,34 @@
+package com.parkmate.parkingreadservice.common.utils;
+
+import io.lettuce.core.RedisException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class RedisUtil<K,V> {
+
+    private final RedisTemplate<K, V> redisTemplate;
+
+    public RedisUtil(RedisTemplate<K, V> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void insert(K key, V value) {
+        try {
+            this.redisTemplate.opsForValue().set(key, value);
+        } catch (Exception e) {
+            throw new RedisException(e.getMessage());
+        }
+    }
+
+    public Optional<V> select(K key) {
+        try {
+            V value = this.redisTemplate.opsForValue().get(key);
+            return Optional.ofNullable(value);
+        } catch (Exception e) {
+            throw new RedisException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/facade/ParkingLotFacade.java
+++ b/src/main/java/com/parkmate/parkingreadservice/facade/ParkingLotFacade.java
@@ -2,11 +2,10 @@ package com.parkmate.parkingreadservice.facade;
 
 import com.parkmate.parkingreadservice.common.utils.RedisUtil;
 import com.parkmate.parkingreadservice.geo.application.GeoService;
-import com.parkmate.parkingreadservice.geo.dto.response.NearByParkingLotResponseDtoList;
+import com.parkmate.parkingreadservice.geo.dto.response.NearbyParkingLotResponseDtoList;
 import com.parkmate.parkingreadservice.geo.dto.response.NearbyParkingLotResponseDto;
 import com.parkmate.parkingreadservice.geo.dto.response.ParkingLotsInRadiusResponse;
 import com.parkmate.parkingreadservice.parkinglotread.application.ParkingLotReadService;
-import com.parkmate.parkingreadservice.parkinglotread.domain.ParkingLotRead;
 import com.parkmate.parkingreadservice.parkinglotread.dto.response.ParkingLotReadResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +21,7 @@ public class ParkingLotFacade {
     private final GeoService geoService;
     private final RedisUtil<String, ParkingLotReadResponseDto> redisUtil;
 
-    public NearByParkingLotResponseDtoList getNearbyParkingLots(double latitude,
+    public NearbyParkingLotResponseDtoList getNearbyParkingLots(double latitude,
                                                                 double longitude,
                                                                 double radius) {
 
@@ -44,6 +43,6 @@ public class ParkingLotFacade {
                     );
                 }).toList();
 
-        return NearByParkingLotResponseDtoList.from(parkingLots);
+        return NearbyParkingLotResponseDtoList.from(parkingLots);
     }
 }

--- a/src/main/java/com/parkmate/parkingreadservice/facade/ParkingLotFacade.java
+++ b/src/main/java/com/parkmate/parkingreadservice/facade/ParkingLotFacade.java
@@ -1,0 +1,49 @@
+package com.parkmate.parkingreadservice.facade;
+
+import com.parkmate.parkingreadservice.common.utils.RedisUtil;
+import com.parkmate.parkingreadservice.geo.application.GeoService;
+import com.parkmate.parkingreadservice.geo.dto.response.NearByParkingLotResponseDtoList;
+import com.parkmate.parkingreadservice.geo.dto.response.NearbyParkingLotResponseDto;
+import com.parkmate.parkingreadservice.geo.dto.response.ParkingLotsInRadiusResponse;
+import com.parkmate.parkingreadservice.parkinglotread.application.ParkingLotReadService;
+import com.parkmate.parkingreadservice.parkinglotread.domain.ParkingLotRead;
+import com.parkmate.parkingreadservice.parkinglotread.dto.response.ParkingLotReadResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ParkingLotFacade {
+
+    private final ParkingLotReadService parkingLotReadService;
+    private final GeoService geoService;
+    private final RedisUtil<String, ParkingLotReadResponseDto> redisUtil;
+
+    public NearByParkingLotResponseDtoList getNearbyParkingLots(double latitude,
+                                                                double longitude,
+                                                                double radius) {
+
+        List<ParkingLotsInRadiusResponse> nearbyParkingLots = geoService.getNearbyParkingLots(latitude, longitude, radius);
+        List<NearbyParkingLotResponseDto> parkingLots = nearbyParkingLots.stream()
+                .map(pl -> {
+                    Optional<ParkingLotReadResponseDto> parkingLot = redisUtil.select(pl.getParkingLotUuid());
+                    if (parkingLot.isPresent()) {
+                        return parkingLot.get().toNearByParkingLotResponseDto(pl.getParkingLotUuid(), pl.getLatitude(), pl.getLongitude(), pl.getDistance());
+                    }
+
+                    ParkingLotReadResponseDto parkingLotReadResponseDto = parkingLotReadService.getParkingLotReadByParkingLotUuid(pl.getParkingLotUuid());
+                    redisUtil.insert(pl.getParkingLotUuid(), parkingLotReadResponseDto);
+                    return parkingLotReadResponseDto.toNearByParkingLotResponseDto(
+                            pl.getParkingLotUuid(),
+                            pl.getLatitude(),
+                            pl.getLongitude(),
+                            pl.getDistance()
+                    );
+                }).toList();
+
+        return NearByParkingLotResponseDtoList.from(parkingLots);
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/application/GeoService.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/application/GeoService.java
@@ -1,0 +1,12 @@
+package com.parkmate.parkingreadservice.geo.application;
+
+import com.parkmate.parkingreadservice.geo.dto.response.ParkingLotsInRadiusResponse;
+
+import java.util.List;
+
+public interface GeoService {
+
+    void addParkingLot(String parkingLotUuid, double latitude, double longitude);
+
+    List<ParkingLotsInRadiusResponse> getNearbyParkingLots(double latitude, double longitude, double radius);
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/application/GeoServiceImplByRedis.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/application/GeoServiceImplByRedis.java
@@ -1,0 +1,61 @@
+package com.parkmate.parkingreadservice.geo.application;
+
+import com.parkmate.parkingreadservice.geo.dto.response.ParkingLotsInRadiusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.geo.*;
+import org.springframework.data.redis.connection.RedisGeoCommands;
+import org.springframework.data.redis.core.GeoOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GeoServiceImplByRedis implements GeoService {
+
+    private final GeoOperations<String, String> geoOperations;
+
+    private static final String GEO_KEY = "geopoints";
+    private static final int LIMIT_PER_RESPONSE = 10;
+    private static final double DISTANCE_PRECISION_FACTOR = 10.0;
+
+    @Override
+    public void addParkingLot(String parkingLotUuid,
+                              double latitude,
+                              double longitude) {
+
+        geoOperations.add(GEO_KEY, new Point(longitude, latitude), parkingLotUuid);
+    }
+
+    @Override
+    public List<ParkingLotsInRadiusResponse> getNearbyParkingLots(double latitude,
+                                                                  double longitude,
+                                                                  double radius) {
+
+        RedisGeoCommands.GeoRadiusCommandArgs args = RedisGeoCommands.GeoRadiusCommandArgs.newGeoRadiusArgs()
+                .includeCoordinates()
+                .includeDistance()
+                .sortAscending()
+                .limit(LIMIT_PER_RESPONSE);
+
+        Point point = new Point(longitude, latitude);
+        Distance distance = new Distance(radius, RedisGeoCommands.DistanceUnit.KILOMETERS);
+        Circle searchArea = new Circle(point, distance);
+
+        GeoResults<RedisGeoCommands.GeoLocation<String>> result = geoOperations.radius(GEO_KEY, searchArea, args);
+        List<GeoResult<RedisGeoCommands.GeoLocation<String>>> content = result == null ? Collections.emptyList() : result.getContent();
+
+        return content.stream()
+                .map(gr -> {
+                    double dist = Math.round(gr.getDistance().getValue() * DISTANCE_PRECISION_FACTOR) / DISTANCE_PRECISION_FACTOR;
+                    return ParkingLotsInRadiusResponse.builder()
+                            .parkingLotUuid(gr.getContent().getName())
+                            .latitude(gr.getContent().getPoint().getY())
+                            .longitude(gr.getContent().getPoint().getX())
+                            .distance(dist)
+                            .build();
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearByParkingLotResponseDtoList.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearByParkingLotResponseDtoList.java
@@ -1,0 +1,33 @@
+package com.parkmate.parkingreadservice.geo.dto.response;
+
+import com.parkmate.parkingreadservice.geo.vo.NearByParkingLotResponseVoList;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class NearByParkingLotResponseDtoList {
+
+    private List<NearbyParkingLotResponseDto> parkingLots;
+
+    @Builder
+    private NearByParkingLotResponseDtoList(List<NearbyParkingLotResponseDto> parkingLots) {
+        this.parkingLots = parkingLots;
+    }
+
+    public static NearByParkingLotResponseDtoList from(List<NearbyParkingLotResponseDto> parkingLots) {
+        return new NearByParkingLotResponseDtoList(parkingLots);
+    }
+
+    public NearByParkingLotResponseVoList toVo() {
+        return NearByParkingLotResponseVoList.builder()
+                .parkingLots(parkingLots.stream()
+                        .map(NearbyParkingLotResponseDto::toVo)
+                        .toList())
+                .build();
+    }
+}
+

--- a/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearbyParkingLotResponseDto.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearbyParkingLotResponseDto.java
@@ -1,0 +1,45 @@
+package com.parkmate.parkingreadservice.geo.dto.response;
+
+import com.parkmate.parkingreadservice.geo.vo.NearByParkingLotResponseVoList;
+import com.parkmate.parkingreadservice.geo.vo.NearbyParkingLotResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NearbyParkingLotResponseDto {
+
+    private String parkingLotUuid;
+    private String name;
+    private String thumbnailUrl;
+    private double longitude;
+    private double latitude;
+    private double distance;
+
+    @Builder
+    private NearbyParkingLotResponseDto(String parkingLotUuid,
+                                       String name,
+                                       String thumbnailUrl,
+                                       double longitude,
+                                       double latitude,
+                                       double distance) {
+        this.parkingLotUuid = parkingLotUuid;
+        this.name = name;
+        this.thumbnailUrl = thumbnailUrl;
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.distance = distance;
+    }
+
+    public NearbyParkingLotResponseVo toVo() {
+        return NearbyParkingLotResponseVo.builder()
+                .parkingLotUuid(parkingLotUuid)
+                .name(name)
+                .thumbnailUrl(thumbnailUrl)
+                .longitude(longitude)
+                .latitude(latitude)
+                .distance(distance)
+                .build();
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearbyParkingLotResponseDto.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearbyParkingLotResponseDto.java
@@ -1,6 +1,5 @@
 package com.parkmate.parkingreadservice.geo.dto.response;
 
-import com.parkmate.parkingreadservice.geo.vo.NearByParkingLotResponseVoList;
 import com.parkmate.parkingreadservice.geo.vo.NearbyParkingLotResponseVo;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearbyParkingLotResponseDtoList.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/NearbyParkingLotResponseDtoList.java
@@ -1,6 +1,6 @@
 package com.parkmate.parkingreadservice.geo.dto.response;
 
-import com.parkmate.parkingreadservice.geo.vo.NearByParkingLotResponseVoList;
+import com.parkmate.parkingreadservice.geo.vo.NearbyParkingLotResponseVoList;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,21 +9,21 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class NearByParkingLotResponseDtoList {
+public class NearbyParkingLotResponseDtoList {
 
     private List<NearbyParkingLotResponseDto> parkingLots;
 
     @Builder
-    private NearByParkingLotResponseDtoList(List<NearbyParkingLotResponseDto> parkingLots) {
+    private NearbyParkingLotResponseDtoList(List<NearbyParkingLotResponseDto> parkingLots) {
         this.parkingLots = parkingLots;
     }
 
-    public static NearByParkingLotResponseDtoList from(List<NearbyParkingLotResponseDto> parkingLots) {
-        return new NearByParkingLotResponseDtoList(parkingLots);
+    public static NearbyParkingLotResponseDtoList from(List<NearbyParkingLotResponseDto> parkingLots) {
+        return new NearbyParkingLotResponseDtoList(parkingLots);
     }
 
-    public NearByParkingLotResponseVoList toVo() {
-        return NearByParkingLotResponseVoList.builder()
+    public NearbyParkingLotResponseVoList toVo() {
+        return NearbyParkingLotResponseVoList.builder()
                 .parkingLots(parkingLots.stream()
                         .map(NearbyParkingLotResponseDto::toVo)
                         .toList())

--- a/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/ParkingLotsInRadiusResponse.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/dto/response/ParkingLotsInRadiusResponse.java
@@ -1,0 +1,28 @@
+package com.parkmate.parkingreadservice.geo.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class ParkingLotsInRadiusResponse {
+
+    private String parkingLotUuid;
+    private double longitude;
+    private double latitude;
+    private double distance;
+
+    @Builder
+    private ParkingLotsInRadiusResponse(String parkingLotUuid,
+                                        double longitude,
+                                        double latitude,
+                                        double distance) {
+        this.parkingLotUuid = parkingLotUuid;
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.distance = distance;
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/vo/NearByParkingLotResponseVoList.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/vo/NearByParkingLotResponseVoList.java
@@ -1,0 +1,19 @@
+package com.parkmate.parkingreadservice.geo.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class NearByParkingLotResponseVoList {
+
+    private List<NearbyParkingLotResponseVo> parkingLots;
+
+    @Builder
+    private NearByParkingLotResponseVoList(List<NearbyParkingLotResponseVo> parkingLots) {
+        this.parkingLots = parkingLots;
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/vo/NearbyParkingLotResponseVo.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/vo/NearbyParkingLotResponseVo.java
@@ -1,0 +1,32 @@
+package com.parkmate.parkingreadservice.geo.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NearbyParkingLotResponseVo {
+
+    private String parkingLotUuid;
+    private String name;
+    private String thumbnailUrl;
+    private double longitude;
+    private double latitude;
+    private double distance;
+
+    @Builder
+    private NearbyParkingLotResponseVo(String parkingLotUuid,
+                                       String name,
+                                       String thumbnailUrl,
+                                       double longitude,
+                                       double latitude,
+                                       double distance) {
+        this.parkingLotUuid = parkingLotUuid;
+        this.name = name;
+        this.thumbnailUrl = thumbnailUrl;
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.distance = distance;
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/geo/vo/NearbyParkingLotResponseVoList.java
+++ b/src/main/java/com/parkmate/parkingreadservice/geo/vo/NearbyParkingLotResponseVoList.java
@@ -8,12 +8,12 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class NearByParkingLotResponseVoList {
+public class NearbyParkingLotResponseVoList {
 
     private List<NearbyParkingLotResponseVo> parkingLots;
 
     @Builder
-    private NearByParkingLotResponseVoList(List<NearbyParkingLotResponseVo> parkingLots) {
+    private NearbyParkingLotResponseVoList(List<NearbyParkingLotResponseVo> parkingLots) {
         this.parkingLots = parkingLots;
     }
 }

--- a/src/main/java/com/parkmate/parkingreadservice/kafka/consumer/ParkingLotReadConsumer.java
+++ b/src/main/java/com/parkmate/parkingreadservice/kafka/consumer/ParkingLotReadConsumer.java
@@ -38,7 +38,7 @@ public class ParkingLotReadConsumer {
             containerFactory = "parkingLotMetadataUpdateListener"
     )
     public void consumeParkingLotMetadataUpdated(ParkingLotMetadataUpdateEvent event) {
-        eventManager.handleParkingLotMetaDataUpdatedEvent(event);
+        eventManager.handleParkingLotMetadataUpdatedEvent(event);
     }
 
     @KafkaListener(

--- a/src/main/java/com/parkmate/parkingreadservice/kafka/event/ParkingLotCreateEvent.java
+++ b/src/main/java/com/parkmate/parkingreadservice/kafka/event/ParkingLotCreateEvent.java
@@ -24,6 +24,8 @@ public class ParkingLotCreateEvent {
     private String name;
     private String phoneNumber;
     private String address;
+    private double latitude;
+    private double longitude;
     private int capacity;
     private Boolean isEvChargingAvailable;
     private Set<String> evChargeTypes;

--- a/src/main/java/com/parkmate/parkingreadservice/kafka/eventmanager/ParkingLotEventManager.java
+++ b/src/main/java/com/parkmate/parkingreadservice/kafka/eventmanager/ParkingLotEventManager.java
@@ -1,0 +1,33 @@
+package com.parkmate.parkingreadservice.kafka.eventmanager;
+
+import com.parkmate.parkingreadservice.geo.application.GeoService;
+import com.parkmate.parkingreadservice.kafka.event.ParkingLotCreateEvent;
+import com.parkmate.parkingreadservice.kafka.event.ParkingLotMetadataUpdateEvent;
+import com.parkmate.parkingreadservice.kafka.event.ParkingLotReactionsUpdateEvent;
+import com.parkmate.parkingreadservice.parkinglotread.application.ParkingLotReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ParkingLotEventManager {
+
+    private final ParkingLotReadService parkingLotReadService;
+    private final GeoService geoService;
+
+    public void handleParkingLotCreatedEvent(ParkingLotCreateEvent event) {
+
+        parkingLotReadService.createParkingLot(event);
+        geoService.addParkingLot(event.getParkingLotUuid(), event.getLatitude(), event.getLongitude());
+    }
+
+    public void handleParkingLotMetaDataUpdatedEvent(ParkingLotMetadataUpdateEvent event) {
+        parkingLotReadService.syncParkingLotMetadata(event);
+    }
+
+    public void handleParkingLotReactionsUpdatedEvent(List<ParkingLotReactionsUpdateEvent> events) {
+        parkingLotReadService.syncParkingLotReactions(events);
+    }
+}

--- a/src/main/java/com/parkmate/parkingreadservice/kafka/eventmanager/ParkingLotEventManager.java
+++ b/src/main/java/com/parkmate/parkingreadservice/kafka/eventmanager/ParkingLotEventManager.java
@@ -23,7 +23,7 @@ public class ParkingLotEventManager {
         geoService.addParkingLot(event.getParkingLotUuid(), event.getLatitude(), event.getLongitude());
     }
 
-    public void handleParkingLotMetaDataUpdatedEvent(ParkingLotMetadataUpdateEvent event) {
+    public void handleParkingLotMetadataUpdatedEvent(ParkingLotMetadataUpdateEvent event) {
         parkingLotReadService.syncParkingLotMetadata(event);
     }
 

--- a/src/main/java/com/parkmate/parkingreadservice/parkinglotread/application/ParkingLotReadServiceImpl.java
+++ b/src/main/java/com/parkmate/parkingreadservice/parkinglotread/application/ParkingLotReadServiceImpl.java
@@ -25,7 +25,7 @@ public class ParkingLotReadServiceImpl implements ParkingLotReadService {
     @Async
     @Override
     public void createParkingLot(ParkingLotCreateEvent parkingLotCreateEvent) {
-        parkingLotReadRepository.save(parkingLotCreateEvent.toEntity());
+        parkingLotReadRepository.create(parkingLotCreateEvent);
     }
 
     @Async

--- a/src/main/java/com/parkmate/parkingreadservice/parkinglotread/dto/response/ParkingLotReadResponseDto.java
+++ b/src/main/java/com/parkmate/parkingreadservice/parkinglotread/dto/response/ParkingLotReadResponseDto.java
@@ -1,5 +1,6 @@
 package com.parkmate.parkingreadservice.parkinglotread.dto.response;
 
+import com.parkmate.parkingreadservice.geo.dto.response.NearbyParkingLotResponseDto;
 import com.parkmate.parkingreadservice.parkinglotread.domain.ParkingLotOption;
 import com.parkmate.parkingreadservice.parkinglotread.domain.ParkingLotRead;
 import com.parkmate.parkingreadservice.parkinglotread.domain.Image;
@@ -96,6 +97,20 @@ public class ParkingLotReadResponseDto {
                 .options(options)
                 .likeCount(likeCount)
                 .dislikeCount(dislikeCount)
+                .build();
+    }
+
+    public NearbyParkingLotResponseDto toNearByParkingLotResponseDto(String parkingLotUuid,
+                                                                     double latitude,
+                                                                     double longitude,
+                                                                     double distance) {
+        return NearbyParkingLotResponseDto.builder()
+                .parkingLotUuid(parkingLotUuid)
+                .name(name)
+                .thumbnailUrl(thumbnailUrl.getImageUrl())
+                .latitude(latitude)
+                .longitude(longitude)
+                .distance(distance)
                 .build();
     }
 }

--- a/src/main/java/com/parkmate/parkingreadservice/parkinglotread/infrastructure/CustomMongoRepository.java
+++ b/src/main/java/com/parkmate/parkingreadservice/parkinglotread/infrastructure/CustomMongoRepository.java
@@ -1,11 +1,14 @@
 package com.parkmate.parkingreadservice.parkinglotread.infrastructure;
 
+import com.parkmate.parkingreadservice.kafka.event.ParkingLotCreateEvent;
 import com.parkmate.parkingreadservice.kafka.event.ParkingLotMetadataUpdateEvent;
 import com.parkmate.parkingreadservice.kafka.event.ParkingLotReactionsUpdateEvent;
 
 import java.util.List;
 
 public interface CustomMongoRepository {
+
+    void create(ParkingLotCreateEvent parkingLotCreateEvent);
 
     void updateParkingLotMetadata(ParkingLotMetadataUpdateEvent parkingLotMetadataUpdateEvent);
 

--- a/src/main/java/com/parkmate/parkingreadservice/parkinglotread/infrastructure/CustomMongoRepositoryImpl.java
+++ b/src/main/java/com/parkmate/parkingreadservice/parkinglotread/infrastructure/CustomMongoRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.parkmate.parkingreadservice.parkinglotread.infrastructure;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.MongoBulkWriteException;
+import com.parkmate.parkingreadservice.kafka.event.ParkingLotCreateEvent;
 import com.parkmate.parkingreadservice.parkinglotread.domain.ParkingLotRead;
 import com.parkmate.parkingreadservice.kafka.event.ParkingLotMetadataUpdateEvent;
 import com.parkmate.parkingreadservice.kafka.event.ParkingLotReactionsUpdateEvent;
@@ -26,6 +27,27 @@ import java.util.Map;
 public class CustomMongoRepositoryImpl implements CustomMongoRepository {
 
     private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void create(ParkingLotCreateEvent parkingLotCreateEvent) {
+
+        Query query = new Query();
+        Update update = new Update();
+
+        query.addCriteria(
+                Criteria.where("parkingLotUuid")
+                        .is(parkingLotCreateEvent.getParkingLotUuid())
+        );
+
+        Map<String, Object> map = createUpdateMap(parkingLotCreateEvent);
+        map.forEach((key, value) -> {
+            if(!key.equals("parkingLotUuid") && value != null) {
+                update.set(key, value);
+            }
+        });
+
+        mongoTemplate.upsert(query, update, ParkingLotRead.class);
+    }
 
     @Override
     public void updateParkingLotMetadata(ParkingLotMetadataUpdateEvent parkingLotMetadataUpdateEvent) {

--- a/src/main/java/com/parkmate/parkingreadservice/parkinglotread/presentation/ParkingLotReadController.java
+++ b/src/main/java/com/parkmate/parkingreadservice/parkinglotread/presentation/ParkingLotReadController.java
@@ -1,14 +1,17 @@
 package com.parkmate.parkingreadservice.parkinglotread.presentation;
 
 import com.parkmate.parkingreadservice.common.response.ApiResponse;
+import com.parkmate.parkingreadservice.facade.ParkingLotFacade;
+import com.parkmate.parkingreadservice.geo.dto.response.ParkingLotsInRadiusResponse;
+import com.parkmate.parkingreadservice.geo.vo.NearByParkingLotResponseVoList;
+import com.parkmate.parkingreadservice.geo.vo.NearbyParkingLotResponseVo;
 import com.parkmate.parkingreadservice.parkinglotread.application.ParkingLotReadService;
 import com.parkmate.parkingreadservice.parkinglotread.vo.response.ParkingLotReadResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/parkingLots")
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ParkingLotReadController {
 
     private final ParkingLotReadService parkingLotReadService;
+    private final ParkingLotFacade parkingLotFacade;
 
     @Operation(
             summary = "주차장 정보 조회",
@@ -28,6 +32,18 @@ public class ParkingLotReadController {
         return ApiResponse.ok(
                 "주차장 정보 조회에 성공했습니다.",
                 parkingLotReadService.getParkingLotReadByParkingLotUuid(parkingLotUuid).toVo()
+        );
+    }
+
+    @GetMapping("/nearby")
+    public ApiResponse<NearByParkingLotResponseVoList> getNearbyParkingLots(
+            @RequestParam double latitude,
+            @RequestParam double longitude,
+            @RequestParam double radius) {
+
+        return ApiResponse.ok(
+                "주변 주차장 정보 조회에 성공했습니다.",
+                parkingLotFacade.getNearbyParkingLots(latitude, longitude, radius).toVo()
         );
     }
 }

--- a/src/main/java/com/parkmate/parkingreadservice/parkinglotread/presentation/ParkingLotReadController.java
+++ b/src/main/java/com/parkmate/parkingreadservice/parkinglotread/presentation/ParkingLotReadController.java
@@ -2,16 +2,12 @@ package com.parkmate.parkingreadservice.parkinglotread.presentation;
 
 import com.parkmate.parkingreadservice.common.response.ApiResponse;
 import com.parkmate.parkingreadservice.facade.ParkingLotFacade;
-import com.parkmate.parkingreadservice.geo.dto.response.ParkingLotsInRadiusResponse;
-import com.parkmate.parkingreadservice.geo.vo.NearByParkingLotResponseVoList;
-import com.parkmate.parkingreadservice.geo.vo.NearbyParkingLotResponseVo;
+import com.parkmate.parkingreadservice.geo.vo.NearbyParkingLotResponseVoList;
 import com.parkmate.parkingreadservice.parkinglotread.application.ParkingLotReadService;
 import com.parkmate.parkingreadservice.parkinglotread.vo.response.ParkingLotReadResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/parkingLots")
@@ -36,7 +32,7 @@ public class ParkingLotReadController {
     }
 
     @GetMapping("/nearby")
-    public ApiResponse<NearByParkingLotResponseVoList> getNearbyParkingLots(
+    public ApiResponse<NearbyParkingLotResponseVoList> getNearbyParkingLots(
             @RequestParam double latitude,
             @RequestParam double longitude,
             @RequestParam double radius) {


### PR DESCRIPTION
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Isuue Number) -->
#5 
## 💡 PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 기타 사소한 변경

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 변경 사항에 대한 테스트를 지켰는가
- [x] 커밋 메시지가 팀 컨벤션을 지켰는가
- [x] 브랜치 명이 규칙에 맞는가
- [x] 기능 정상 동작 확인 완료

##  📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
parking-service에서 구현하던 현재좌표 기준 주차장 조회 기능을 read-service로 옮겼습니다. 이유는 썸네일url 등 join해서 가져와야될 정보가 존재하고 차후에 추가될 평점 데이터도 read-service에서 조회해야 하기에 기능 자체를 read 서비스에 구현했습니다.
데이터를 삽입하는 과정에서 redis에서 오류가 발생하여 mongodb에 주차장uuid가 같은 데이터가 중복으로 저장되는 문제가 있었습니다.  우선은 주차장uuid에 멱등성을 보장해서 id를 기준으로 단순 save하던 로직을 주차장uuid 값을 기준으로 upsert 하는 로직으로 변경했습니다.

